### PR TITLE
2.4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Loop Weather Services
+Copyright (c) 2019 Loop Weather Services LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Sources/WXKDarkSky/DarkSkyRequest.swift
+++ b/Sources/WXKDarkSky/DarkSkyRequest.swift
@@ -1,20 +1,23 @@
 //
-//  WXKDarkSkyRequest.swift
+//  DarkSkyRequest.swift
 //  WXKDarkSky
 //
-//  © 2018 Loop Weather Services LLC. Licensed under the MIT License.
+//  © 2019 Loop Weather Services LLC. Licensed under the MIT License.
 //
 //  Please see the included LICENSE file for details.
 //
 
 import Foundation
 
+@available(*, deprecated, renamed: "DarkSkyRequest")
+public typealias WXKDarkSkyRequest = DarkSkyRequest
+
 /// The WXKDarkSkyRequest class contains some networking utilities for working with the Dark Sky API. You initialize this class with your Dark Sky API key, like so:
 /// ```swift
 /// WXKDarkSkyRequest(key: "YOUR KEY HERE").loadData(...)
 /// ```
 /// - warning: This class should **never** be used in client-side code. Doing so puts your API key at risk of being compromised, and should your API key be compromised, there is no way to reset your API key without breaking deployed client-side code with the old key. Instead, use a server-side solution to obtain data from the Dark Sky API.
-public class WXKDarkSkyRequest {
+public class DarkSkyRequest {
     /// Your Dark Sky API key.
     var key: String
 
@@ -54,18 +57,18 @@ public class WXKDarkSkyRequest {
                         completionHandler(decoded, nil)
                     } catch {
                         // Something was wrong with the response such that it could not be decoded.
-                        completionHandler(nil, WXKDarkSkyError.malformedResponse)
+                        completionHandler(nil, DarkSkyError.malformedResponse)
                     }
                 } else {
                     // ...something went wrong? Received data, but the status code was not 200 (OK).
-                    completionHandler(nil, WXKDarkSkyError.couldNotRetrieveData)
+                    completionHandler(nil, DarkSkyError.couldNotRetrieveData)
                 }
             })
 
             dataTask?.resume()
         } else {
             // Some error occurred in...generating the URL. The circumstances behind this are so unlikely that this will likely never be called, but it's helpful to open a door to handle it.
-            completionHandler(nil, WXKDarkSkyError.unspecified)
+            completionHandler(nil, DarkSkyError.unspecified)
         }
     }
 

--- a/Sources/WXKDarkSky/DarkSkyRequest.swift
+++ b/Sources/WXKDarkSky/DarkSkyRequest.swift
@@ -12,9 +12,9 @@ import Foundation
 @available(*, deprecated, renamed: "DarkSkyRequest")
 public typealias WXKDarkSkyRequest = DarkSkyRequest
 
-/// The WXKDarkSkyRequest class contains some networking utilities for working with the Dark Sky API. You initialize this class with your Dark Sky API key, like so:
+/// The DarkSkyRequest class contains some networking utilities for working with the Dark Sky API. You initialize this class with your Dark Sky API key, like so:
 /// ```swift
-/// WXKDarkSkyRequest(key: "YOUR KEY HERE").loadData(...)
+/// DarkSkyRequest(key: "YOUR KEY HERE").loadData(...)
 /// ```
 /// - warning: This class should **never** be used in client-side code. Doing so puts your API key at risk of being compromised, and should your API key be compromised, there is no way to reset your API key without breaking deployed client-side code with the old key. Instead, use a server-side solution to obtain data from the Dark Sky API.
 public class DarkSkyRequest {
@@ -38,7 +38,7 @@ public class DarkSkyRequest {
         dataTask?.cancel()
 
         // Build a Dark Sky API URL.
-        let url = buildDarkSkyURL(point: point, time: time, options: options)
+        let url = buildURL(point: point, time: time, options: options)
 
         if let url = url {
             // Set up a URL load request.
@@ -64,14 +64,33 @@ public class DarkSkyRequest {
             completionHandler(nil, DarkSkyError.unspecified)
         }
     }
-
-    /// Builds a URL for a Dark Sky API requests.
-    /// - parameter key: The API key to use for the request.
-    /// - parameter point: A latitude-longitude pair for the request.
-    /// - parameter time: If present, the time for a Time Machine request before or after the current time.
-    /// - parameter options: Options to use for the request.
-    /// - returns: If a URL can be created, returns a `URL`. If not, returns nil.
+    
+    /**
+     Builds a URL for a Dark Sky API requests.
+     
+     - note: This method is deprecated in WXKDarkSky 2.4.0 and will be removed in a future release. Use `buildURL(point:time:options:) instead.
+     
+     - parameter key: The API key to use for the request.
+     - parameter point: A latitude-longitude pair for the request.
+     - parameter time: If present, the time for a Time Machine request before or after the current time.
+     - parameter options: Options to use for the request.
+     - returns: If a URL can be created, returns a `URL`. If not, returns nil.
+     */
+    @available(*, deprecated, renamed: "buildURL(point:time:options:)")
     public func buildDarkSkyURL(point: Point, time: Date? = nil, options: Options = Options.defaults) -> URL? {
+        return buildURL(point: point, time: time, options: options)
+    }
+
+    /**
+     Builds a URL for a Dark Sky API requests.
+     
+     - parameter key: The API key to use for the request.
+     - parameter point: A latitude-longitude pair for the request.
+     - parameter time: If present, the time for a Time Machine request before or after the current time.
+     - parameter options: Options to use for the request.
+     - returns: If a URL can be created, returns a `URL`. If not, returns nil.
+    */
+    public func buildURL(point: Point, time: Date? = nil, options: Options = Options.defaults) -> URL? {
         /// String describing the requested latitude-longitude pair.
         let coordinates = String(describing: point)
 

--- a/Sources/WXKDarkSky/DarkSkyRequest.swift
+++ b/Sources/WXKDarkSky/DarkSkyRequest.swift
@@ -30,7 +30,7 @@ public class DarkSkyRequest {
     /// - parameter time: The time for a Time Machine request; defaults to nil for current data.
     /// - parameter options: A set of options for fulfilling the request, such as units and language.
     /// - parameter completionHandler: A code block to handle the successful completion, or errors in completion, of the request.
-    public func loadData(point: Point, time: Date? = nil, options: Options = Options.defaults, completionHandler: @escaping (WXKDarkSkyResponse?, Error?) -> Void) {
+    public func loadData(point: Point, time: Date? = nil, options: Options = Options.defaults, completionHandler: @escaping (DarkSkyResponse?, Error?) -> Void) {
         // Set up a data task variable.
         var dataTask: URLSessionDataTask?
 
@@ -47,16 +47,9 @@ public class DarkSkyRequest {
                 if let error = error {
                     completionHandler(nil, error)
                 } else if let data = data, let response = response as? HTTPURLResponse, response.statusCode == 200 {
-                    // Successfully retrieved data from the Dark Sky API.
-                    let decoder = JSONDecoder()
-                    decoder.dateDecodingStrategy = .secondsSince1970
-
-                    do {
-                        // Attempt to decode the response into a WXKDarkSkyResponse object.
-                        let decoded = try decoder.decode(WXKDarkSkyResponse.self, from: data)
-                        completionHandler(decoded, nil)
-                    } catch {
-                        // Something was wrong with the response such that it could not be decoded.
+                    if let darkSkyResponse = DarkSkyResponse(data: data) {
+                        completionHandler(darkSkyResponse, nil)
+                    } else {
                         completionHandler(nil, DarkSkyError.malformedResponse)
                     }
                 } else {

--- a/Sources/WXKDarkSky/DarkSkyResponse.swift
+++ b/Sources/WXKDarkSky/DarkSkyResponse.swift
@@ -12,7 +12,7 @@ import Foundation
 @available(*, deprecated, renamed: "DarkSkyResponse")
 public typealias WXKDarkSkyResponse = DarkSkyResponse
 
-/// The `WXKDarkSkyResponse` struct contains support for quick Swift-based encoding/decoding of responses from the Dark Sky API.
+/// The `DarkSkyResponse` struct contains support for quick Swift-based encoding/decoding of responses from the Dark Sky API.
 public struct DarkSkyResponse: Codable {
     /// The requested point's latitude.
     public var latitude: Double
@@ -21,22 +21,22 @@ public struct DarkSkyResponse: Codable {
     /// The requested point's timezone.
     public var timezone: String
     /// Current conditions for the requested point.
-    public var currently: WXKDarkSkyDataPoint?
+    public var currently: DarkSkyDataPoint?
     /// Minute-by-minute forecast for the next hour at the requested point.
-    public var minutely: WXKDarkSkyDataBlock?
+    public var minutely: DarkSkyDataBlock?
     /// Hourly forecast for the next 48 hours at the requested point.
-    public var hourly: WXKDarkSkyDataBlock?
+    public var hourly: DarkSkyDataBlock?
     /// Daily forecast for the next week at the requested point.
-    public var daily: WXKDarkSkyDataBlock?
+    public var daily: DarkSkyDataBlock?
     /// Any active alerts for the requested point.
-    public var alerts: [WXKDarkSkyAlert]?
+    public var alerts: [DarkSkyAlert]?
     /// Metadata about the data returned for the requested point.
-    public var flags: WXKDarkSkyFlags?
+    public var flags: DarkSkyFlags?
     
     /**
-     Creates a WXKDarkSkyResponse struct from Dark Sky JSON data, if possible. This initializer is simply a wrapper around a `JSONDecoder`.
+     Creates a DarkSkyResponse struct from Dark Sky JSON data, if possible. This initializer is simply a wrapper around a `JSONDecoder`.
      
-     This initializer will fail if the Dark Sky JSON provided to it cannot be decoded by a `JSONDecoder` into a `WXKDarkSkyResponse` object for whatever reason, such as an incomplete download or other badly formatted JSON.
+     This initializer will fail if the Dark Sky JSON provided to it cannot be decoded by a `JSONDecoder` into a `DarkSkyResponse` object for whatever reason, such as an incomplete download or other badly formatted JSON.
      
      - parameter data: Dark Sky JSON `Data` to be converted.
     */
@@ -60,14 +60,14 @@ public struct DarkSkyResponse: Codable {
     }
 
     /**
-     Converts Dark Sky response JSON into a WXKDarkSkyResponse struct, if possible.
+     Converts Dark Sky response JSON into a DarkSkyResponse struct, if possible.
      
-     This method will fail if the Dark Sky JSON provided to it cannot be decoded by a `JSONDecoder` into a `WXKDarkSkyResponse` object for whatever reason, such as an incomplete download or other badly formatted JSON.
+     This method will fail if the Dark Sky JSON provided to it cannot be decoded by a `JSONDecoder` into a `DarkSkyResponse` object for whatever reason, such as an incomplete download or other badly formatted JSON.
      
      - note: This method is deprecated in WXKDarkSky 2.4.0 and will be removed in a future release. Instead, use `init(data:)`. Thus, any instances of `WXKDarkSkyResponse.converted(from: Data)` can be replaced with `DarkSkyResponse(data: Data)`.
      
      - parameter data: Dark Sky JSON `Data` to be converted.
-     - returns: If the conversion was successful, the method returns a WXKDarkSkyReponse struct. Otherwise, the method will return nil.
+     - returns: If the conversion was successful, the method returns a DarkSkyReponse struct. Otherwise, the method will return nil.
     */
     @available(*, deprecated, message: "converted(from:) is deprecated and will be removed in a future release. Please use init(data:) instead.")
     public static func converted(from data: Data) -> DarkSkyResponse? {
@@ -82,8 +82,8 @@ public struct DarkSkyResponse: Codable {
     }
 }
 
-/// The `WXKDarkSkyDataPoint` struct encapsulates information about the weather at a given time from the Dark Sky API. All properties except `time` are optional.
-public struct WXKDarkSkyDataPoint: Codable {
+/// The `DarkSkyDataPoint` struct encapsulates information about the weather at a given time from the Dark Sky API. All properties except `time` are optional.
+public struct DarkSkyDataPoint: Codable {
     /// The UNIX time representing the beginning of the data point. For example, for current data points, this is the current time, and for daily data points, it's midnight. This property is required.
     public var time: Date
     /// The apparent temperature (heat index or wind chill) for the data point.
@@ -158,18 +158,18 @@ public struct WXKDarkSkyDataPoint: Codable {
     public var windSpeed: Double?
 }
 
-/// The `WXKDarkSkyDataBlock` struct contains an array of data points for a period of time, such as hourly forecasts for the next 2 days or daily forecasts for the next week.
-public struct WXKDarkSkyDataBlock: Codable {
+/// The `DarkSkyDataBlock` struct contains an array of data points for a period of time, such as hourly forecasts for the next 2 days or daily forecasts for the next week.
+public struct DarkSkyDataBlock: Codable {
     /// An array of data points for the data block. This is required (but could be empty).
-    public var data: [WXKDarkSkyDataPoint]
+    public var data: [DarkSkyDataPoint]
     /// A string summarizing the data block.
     public var summary: String?
     /// An icon name from Dark Sky summarizing the data block.
     public var icon: String?
 }
 
-/// The `WXKDarkSkyFlags` struct contains metadata about your forecast request.
-public struct WXKDarkSkyFlags: Codable {
+/// The `DarkSkyFlags` struct contains metadata about your forecast request.
+public struct DarkSkyFlags: Codable {
     /// If this value is present, there was an issue getting data for the request.
     public var darkSkyUnavailable: Bool?
     /// An array of strings with identifiers for data sources used in fulfilling the request.
@@ -180,8 +180,8 @@ public struct WXKDarkSkyFlags: Codable {
     public var units: String
 }
 
-/// The `WXKDarkSkyAlert` struct contains information about a hypothetical alert in effect at the time of the forecast request.
-public struct WXKDarkSkyAlert: Codable {
+/// The `DarkSkyAlert` struct contains information about a hypothetical alert in effect at the time of the forecast request.
+public struct DarkSkyAlert: Codable {
     /// A detailed description of the alert, usually the product text.
     public var description: String
     /// The expiration time as a UNIX time, which may possibly be undefined.

--- a/Sources/WXKDarkSky/DarkSkyResponse.swift
+++ b/Sources/WXKDarkSky/DarkSkyResponse.swift
@@ -1,16 +1,19 @@
 //
-//  WXKDarkSkyResponse.swift
+//  DarkSkyResponse.swift
 //  WXKDarkSky
 //
-//  © 2018 Loop Weather Services LLC. Licensed under the MIT License.
+//  © 2019 Loop Weather Services LLC. Licensed under the MIT License.
 //
 //  Please see the included LICENSE file for details.
 //
 
 import Foundation
 
+@available(*, deprecated, renamed: "DarkSkyResponse")
+public typealias WXKDarkSkyResponse = DarkSkyResponse
+
 /// The `WXKDarkSkyResponse` struct contains support for quick Swift-based encoding/decoding of responses from the Dark Sky API.
-public struct WXKDarkSkyResponse: Codable {
+public struct DarkSkyResponse: Codable {
     /// The requested point's latitude.
     public var latitude: Double
     /// The requested point's longitude.
@@ -29,15 +32,49 @@ public struct WXKDarkSkyResponse: Codable {
     public var alerts: [WXKDarkSkyAlert]?
     /// Metadata about the data returned for the requested point.
     public var flags: WXKDarkSkyFlags?
-
-    /// Converts Dark Sky response JSON into a WXKDarkSkyResponse struct, if possible.
-    /// - parameter data: Dark Sky JSON `Data` to be converted.
-    /// - returns: If the conversion was successful, the method returns a WXKDarkSkyReponse struct. Otherwise, the method will return nil.
-    public static func converted(from data: Data) -> WXKDarkSkyResponse? {
+    
+    /**
+     Creates a WXKDarkSkyResponse struct from Dark Sky JSON data, if possible. This initializer is simply a wrapper around a `JSONDecoder`.
+     
+     This initializer will fail if the Dark Sky JSON provided to it cannot be decoded by a `JSONDecoder` into a `WXKDarkSkyResponse` object for whatever reason, such as an incomplete download or other badly formatted JSON.
+     
+     - parameter data: Dark Sky JSON `Data` to be converted.
+    */
+    public init?(data: Data) {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .secondsSince1970
         do {
-            let response = try decoder.decode(WXKDarkSkyResponse.self, from: data)
+            let response = try decoder.decode(DarkSkyResponse.self, from: data)
+            self.latitude = response.latitude
+            self.longitude = response.longitude
+            self.timezone = response.timezone
+            self.currently = response.currently
+            self.minutely = response.minutely
+            self.hourly = response.hourly
+            self.daily = response.daily
+            self.alerts = response.alerts
+            self.flags = response.flags
+        } catch {
+            return nil
+        }
+    }
+
+    /**
+     Converts Dark Sky response JSON into a WXKDarkSkyResponse struct, if possible.
+     
+     This method will fail if the Dark Sky JSON provided to it cannot be decoded by a `JSONDecoder` into a `WXKDarkSkyResponse` object for whatever reason, such as an incomplete download or other badly formatted JSON.
+     
+     - note: This method is deprecated in WXKDarkSky 2.4.0 and will be removed in a future release. Instead, use `init(data:)`. Thus, any instances of `WXKDarkSkyResponse.converted(from: Data)` can be replaced with `DarkSkyResponse(data: Data)`.
+     
+     - parameter data: Dark Sky JSON `Data` to be converted.
+     - returns: If the conversion was successful, the method returns a WXKDarkSkyReponse struct. Otherwise, the method will return nil.
+    */
+    @available(*, deprecated, message: "converted(from:) is deprecated and will be removed in a future release. Please use init(data:) instead.")
+    public static func converted(from data: Data) -> DarkSkyResponse? {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        do {
+            let response = try decoder.decode(DarkSkyResponse.self, from: data)
             return response
         } catch {
             return nil

--- a/Sources/WXKDarkSky/DataBlock.swift
+++ b/Sources/WXKDarkSky/DataBlock.swift
@@ -2,14 +2,14 @@
 //  DataBlock.swift
 //  WXKDarkSky
 //
-//  © 2018 Loop Weather Services LLC. Licensed under the MIT License.
+//  © 2019 Loop Weather Services LLC. Licensed under the MIT License.
 //
 //  Please see the included LICENSE file for details.
 //
 
 import Foundation
 
-extension WXKDarkSkyRequest {
+extension DarkSkyRequest {
     /// Data blocks provided by the Dark Sky API. Used to exclude certain data blocks in a networking request.
     public enum DataBlock: String, CustomStringConvertible {
         /// The current conditions pertaining to the request.

--- a/Sources/WXKDarkSky/Date+unixTime.swift
+++ b/Sources/WXKDarkSky/Date+unixTime.swift
@@ -2,7 +2,7 @@
 //  Date+unixTime.swift
 //  WXKDarkSky
 //
-//  © 2018 Loop Weather Services LLC. Licensed under the MIT License.
+//  © 2019 Loop Weather Services LLC. Licensed under the MIT License.
 //
 //  Please see the included LICENSE file for details.
 //

--- a/Sources/WXKDarkSky/Date+unixTime.swift
+++ b/Sources/WXKDarkSky/Date+unixTime.swift
@@ -10,6 +10,9 @@
 import Foundation
 
 extension Date {
+    /**
+     Returns the Unix time as an integer.
+    */
     internal var unixTime: Int {
         return Int(timeIntervalSince1970.rounded())
     }

--- a/Sources/WXKDarkSky/Error.swift
+++ b/Sources/WXKDarkSky/Error.swift
@@ -2,15 +2,15 @@
 //  Error.swift
 //  WXKDarkSky
 //
-//  © 2018 Loop Weather Services LLC. Licensed under the MIT License.
+//  © 2019 Loop Weather Services LLC. Licensed under the MIT License.
 //
 //  Please see the included LICENSE file for details.
 //
 
 import Foundation
 
-/// The WXKDarkSkyError enum contains some possible error cases for errors that may be encountered in using WXKDarkSky.
-public enum WXKDarkSkyError: String, Error {
+/// The DarkSkyError enum contains some possible error cases for errors that may be encountered in using WXKDarkSky.
+public enum DarkSkyError: String, Error {
     case couldNotRetrieveData = "Could not retrieve data. This error is likely on Dark Sky's end."
     case malformedResponse = "Could not decode data from Dark Sky into a WXKDarkSkyResponse object."
     case unspecified = "An unspecified error has occurred in creating the Dark Sky API request."

--- a/Sources/WXKDarkSky/Language.swift
+++ b/Sources/WXKDarkSky/Language.swift
@@ -2,14 +2,14 @@
 //  Language.swift
 //  WXKDarkSky
 //
-//  © 2018 Loop Weather Services LLC. Licensed under the MIT License.
+//  © 2019 Loop Weather Services LLC. Licensed under the MIT License.
 //
 //  Please see the included LICENSE file for details.
 //
 
 import Foundation
 
-extension WXKDarkSkyRequest {
+extension DarkSkyRequest {
     /// Languages supported by the Dark Sky API.
     public enum Language: String, CustomStringConvertible {
         /// Indicates that a Dark Sky request should be handled in the Arabic language.

--- a/Sources/WXKDarkSky/Options.swift
+++ b/Sources/WXKDarkSky/Options.swift
@@ -2,17 +2,17 @@
 //  Options.swift
 //  WXKDarkSky
 //
-//  © 2018 Loop Weather Services LLC. Licensed under the MIT License.
+//  © 2019 Loop Weather Services LLC. Licensed under the MIT License.
 //
 //  Please see the included LICENSE file for details.
 //
 
 import Foundation
 
-extension WXKDarkSkyRequest {
+extension DarkSkyRequest {
     /// Options for loading data from the Dark Sky API.
     public class Options: Equatable {
-        public static func == (lhs: WXKDarkSkyRequest.Options, rhs: WXKDarkSkyRequest.Options) -> Bool {
+        public static func == (lhs: DarkSkyRequest.Options, rhs: DarkSkyRequest.Options) -> Bool {
             if lhs.exclude == rhs.exclude &&
                 lhs.extendHourly == rhs.extendHourly &&
                 lhs.language == rhs.language &&

--- a/Sources/WXKDarkSky/Point.swift
+++ b/Sources/WXKDarkSky/Point.swift
@@ -2,14 +2,14 @@
 //  Point.swift
 //  WXKDarkSky
 //
-//  © 2018 Loop Weather Services LLC. Licensed under the MIT License.
+//  © 2019 Loop Weather Services LLC. Licensed under the MIT License.
 //
 //  Please see the included LICENSE file for details.
 //
 
 import Foundation
 
-extension WXKDarkSkyRequest {
+extension DarkSkyRequest {
     /// Encapsulates a latitude-longitude coordinate pair.
     public struct Point: CustomStringConvertible {
         /// A latitude coordinate.

--- a/Sources/WXKDarkSky/Units.swift
+++ b/Sources/WXKDarkSky/Units.swift
@@ -2,14 +2,14 @@
 //  Units.swift
 //  WXKDarkSky
 //
-//  © 2018 Loop Weather Services LLC. Licensed under the MIT License.
+//  © 2019 Loop Weather Services LLC. Licensed under the MIT License.
 //
 //  Please see the included LICENSE file for details.
 //
 
 import Foundation
 
-extension WXKDarkSkyRequest {
+extension DarkSkyRequest {
     /// Sets of units supported by the Dark Sky API.
     public enum Units: String, CustomStringConvertible {
         /// Automatically determine units based on location.

--- a/Tests/WXKDarkSkyTests/WXKDarkSkyTests.swift
+++ b/Tests/WXKDarkSkyTests/WXKDarkSkyTests.swift
@@ -9,50 +9,48 @@ class WXKDarkSkyTests: XCTestCase {
 		
         // This just runs some tests to make sure that the results from the JSONDecoder are what we'd expect to see.
 		let data = testJSON.data(using: .utf8)!
-		
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
         
-		let response = try! decoder.decode(WXKDarkSkyResponse.self, from: data)
+        if let response = DarkSkyResponse(data: data) {
 		
-		// Is the latitude what we'd expect?
-		let latitude = response.latitude
-		XCTAssertEqual(latitude, 37.8267)
-        
-        // What about the current time?
-        let currentTime = response.currently!.time
-		XCTAssertEqual(currentTime, Date(timeIntervalSince1970: 1514937653))
-        
-		// What about the current temperature?
-		if let currently = response.currently {
-			if let temperature = currently.temperature {
-				XCTAssertEqual(temperature, 59.35)
-			} else {
-				XCTFail()
-			}
-		} else {
-			XCTFail()
-		}
-		
-		// And what about "tomorrow's" high temperature?
-		if let daily = response.daily {
-			let tomorrow = daily.data[1]
-			if let tomorrowHigh = tomorrow.temperatureHigh {
-				XCTAssertEqual(tomorrowHigh, 58.98)
-			} else {
-				XCTFail()
-			}
-		} else {
-			XCTFail()
-		}
+            // Is the latitude what we'd expect?
+            let latitude = response.latitude
+            XCTAssertEqual(latitude, 37.8267)
+            
+            // What about the current time?
+            let currentTime = response.currently!.time
+            XCTAssertEqual(currentTime, Date(timeIntervalSince1970: 1514937653))
+            
+            // What about the current temperature?
+            if let currently = response.currently {
+                if let temperature = currently.temperature {
+                    XCTAssertEqual(temperature, 59.35)
+                } else {
+                    XCTFail()
+                }
+            } else {
+                XCTFail()
+            }
+            
+            // And what about "tomorrow's" high temperature?
+            if let daily = response.daily {
+                let tomorrow = daily.data[1]
+                if let tomorrowHigh = tomorrow.temperatureHigh {
+                    XCTAssertEqual(tomorrowHigh, 58.98)
+                } else {
+                    XCTFail()
+                }
+            } else {
+                XCTFail()
+            }
+        }
     }
 	
 	func testURLBuilder() {
-		let point = WXKDarkSkyRequest.Point(latitude: 37.4, longitude: -96.5)
+        let point = DarkSkyRequest.Point(latitude: 37.4, longitude: -96.5)
 		let key = "fish"
-		let options = WXKDarkSkyRequest.Options(exclude: [.currently, .alerts], extendHourly: true)
+        let options = DarkSkyRequest.Options(exclude: [.currently, .alerts], extendHourly: true)
 		
-		if let url = WXKDarkSkyRequest(key: key).buildDarkSkyURL(point: point, options: options) {
+        if let url = DarkSkyRequest(key: key).buildDarkSkyURL(point: point, options: options) {
 			let string = String(describing: url)
 			NSLog(string)
 			XCTAssert(string == "https://api.darksky.net/forecast/\(key)/37.4,-96.5?exclude=currently,alerts&extend=hourly")
@@ -60,7 +58,7 @@ class WXKDarkSkyTests: XCTestCase {
 			XCTFail()
 		}
 		
-		if let url = WXKDarkSkyRequest(key: key).buildDarkSkyURL(point: point) {
+        if let url = DarkSkyRequest(key: key).buildDarkSkyURL(point: point) {
 			let string = String(describing: url)
 			NSLog(string)
 			XCTAssert(string == "https://api.darksky.net/forecast/\(key)/37.4,-96.5")

--- a/Tests/WXKDarkSkyTests/WXKDarkSkyTests.swift
+++ b/Tests/WXKDarkSkyTests/WXKDarkSkyTests.swift
@@ -50,7 +50,7 @@ class WXKDarkSkyTests: XCTestCase {
 		let key = "fish"
         let options = DarkSkyRequest.Options(exclude: [.currently, .alerts], extendHourly: true)
 		
-        if let url = DarkSkyRequest(key: key).buildDarkSkyURL(point: point, options: options) {
+        if let url = DarkSkyRequest(key: key).buildURL(point: point, options: options) {
 			let string = String(describing: url)
 			NSLog(string)
 			XCTAssert(string == "https://api.darksky.net/forecast/\(key)/37.4,-96.5?exclude=currently,alerts&extend=hourly")
@@ -58,7 +58,7 @@ class WXKDarkSkyTests: XCTestCase {
 			XCTFail()
 		}
 		
-        if let url = DarkSkyRequest(key: key).buildDarkSkyURL(point: point) {
+        if let url = DarkSkyRequest(key: key).buildURL(point: point) {
 			let string = String(describing: url)
 			NSLog(string)
 			XCTAssert(string == "https://api.darksky.net/forecast/\(key)/37.4,-96.5")

--- a/WXKDarkSky.podspec
+++ b/WXKDarkSky.podspec
@@ -1,15 +1,7 @@
-#
-#  Be sure to run `pod spec lint WXKDarkSky.podspec' to ensure this is a
-#  valid spec and to remove all comments including this before submitting the spec.
-#
-#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
-#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
-#
-
 Pod::Spec.new do |s|
 
   s.name         = "WXKDarkSky"
-  s.version      = "2.3.0"
+  s.version      = "2.4.0"
   s.summary      = "A pure-Swift Codable layer over the Dark Sky API."
   s.description  = <<-DESC
                    WXKDarkSky is a simple library written completely in Swift that

--- a/WXKDarkSky.xcodeproj/project.pbxproj
+++ b/WXKDarkSky.xcodeproj/project.pbxproj
@@ -28,8 +28,8 @@
 		OBJ_34 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Options.swift */; };
 		OBJ_35 /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Point.swift */; };
 		OBJ_36 /* Units.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Units.swift */; };
-		OBJ_37 /* WXKDarkSkyRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* WXKDarkSkyRequest.swift */; };
-		OBJ_38 /* WXKDarkSkyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* WXKDarkSkyResponse.swift */; };
+		OBJ_37 /* DarkSkyRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* DarkSkyRequest.swift */; };
+		OBJ_38 /* DarkSkyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* DarkSkyResponse.swift */; };
 		OBJ_45 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_56 /* WXKDarkSkyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* WXKDarkSkyTests.swift */; };
 		OBJ_58 /* WXKDarkSky.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "WXKDarkSky::WXKDarkSky::Product" /* WXKDarkSky.framework */; };
@@ -59,8 +59,8 @@
 		OBJ_13 /* Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		OBJ_14 /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
 		OBJ_15 /* Units.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Units.swift; sourceTree = "<group>"; };
-		OBJ_16 /* WXKDarkSkyRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WXKDarkSkyRequest.swift; sourceTree = "<group>"; };
-		OBJ_17 /* WXKDarkSkyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WXKDarkSkyResponse.swift; sourceTree = "<group>"; };
+		OBJ_16 /* DarkSkyRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkSkyRequest.swift; sourceTree = "<group>"; };
+		OBJ_17 /* DarkSkyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkSkyResponse.swift; sourceTree = "<group>"; };
 		OBJ_20 /* WXKDarkSkyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WXKDarkSkyTests.swift; sourceTree = "<group>"; };
 		OBJ_21 /* WXKDarkSky */ = {isa = PBXFileReference; lastKnownFileType = text; path = WXKDarkSky; sourceTree = SOURCE_ROOT; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -144,8 +144,8 @@
 				OBJ_13 /* Options.swift */,
 				OBJ_14 /* Point.swift */,
 				OBJ_15 /* Units.swift */,
-				OBJ_16 /* WXKDarkSkyRequest.swift */,
-				OBJ_17 /* WXKDarkSkyResponse.swift */,
+				OBJ_16 /* DarkSkyRequest.swift */,
+				OBJ_17 /* DarkSkyResponse.swift */,
 			);
 			name = WXKDarkSky;
 			path = Sources/WXKDarkSky;
@@ -250,8 +250,8 @@
 				OBJ_34 /* Options.swift in Sources */,
 				OBJ_35 /* Point.swift in Sources */,
 				OBJ_36 /* Units.swift in Sources */,
-				OBJ_37 /* WXKDarkSkyRequest.swift in Sources */,
-				OBJ_38 /* WXKDarkSkyResponse.swift in Sources */,
+				OBJ_37 /* DarkSkyRequest.swift in Sources */,
+				OBJ_38 /* DarkSkyResponse.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
* Renames `WXKDarkSkyResponse` to `DarkSkyResponse` and `WXKDarkSkyRequest` to `DarkSkyRequest`. The old prefixed names are available as typealiases but deprecated and will be removed in a future release.
* Renames `DarkSkyRequest.buildDarkSkyURL(...)` to `DarkSkyRequest.buildURL(...)`. The old method is available but deprecated and will be removed in a future release.
* Deprecates `DarkSkyResponse.converted(from:)` in favor of a failable init `DarkSkyResponse(data:)`.
* Adds support for several new languages.